### PR TITLE
hide the TOC on mobile view

### DIFF
--- a/src/pages/api.js
+++ b/src/pages/api.js
@@ -21,7 +21,7 @@ class PageApi extends Tonic {
                 <app-tree id="app-tree"></app-tree>
               </tonic-split-left>
 
-              <tonic-split-right width="75%">
+              <tonic-split-right>
                 <markdown-module class="code" src="src/docs/api.md"></markdown-module>
                 <app-footer js-bundle="true"></app-footer>
               </tonic-split-right>

--- a/src/pages/guides.js
+++ b/src/pages/guides.js
@@ -22,7 +22,7 @@ class PageGuides extends Tonic {
                 <app-tree id="app-tree"></app-tree>
               </tonic-split-left>
 
-              <tonic-split-right width="75%">
+              <tonic-split-right>
                 <markdown-module src="src/docs/guide-fte.md"></markdown-module>
                 <markdown-module src="src/docs/guide-apple.md"></markdown-module>
                 <markdown-module src="src/docs/guide-desktop.md"></markdown-module>

--- a/src/styles/page-base.css
+++ b/src/styles/page-base.css
@@ -31,6 +31,7 @@ body.api tonic-split {
 body.api tonic-split tonic-split-right {
   scroll-behavior: smooth;
   overflow: scroll;
+  width: 75%;
 }
 
 body.api tonic-split tonic-split-right markdown-module {
@@ -80,6 +81,18 @@ time {
   body main {
     margin: 40px;
     margin-bottom: 100px;
+  }
+
+  .tonic--split-handle {
+    display: none;
+  }
+
+  body.api tonic-split-left {
+    display: none;
+  }
+
+  body.api tonic-split tonic-split-right {
+    width: 100%;
   }
 
   body footer .content {

--- a/src/styles/pages/index.css
+++ b/src/styles/pages/index.css
@@ -235,6 +235,10 @@ body > header .centered {
   width: 50%;
 }
 
+tonic-split-right {
+  width: 75%;
+}
+
 @media (max-width: 699px) {
   #value-props {
     display: block;


### PR DESCRIPTION
Per discord discussion, hide the table of contents in mobile view

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/5776508/201783546-3ef16b58-c125-4fdb-a6bb-5b0ffdb9bac4.png">

local preview is `npm run build && ecstatic ./build`

`ecstatic` is just a static file server; you would need to install it globally in that command.
