### PR TITLE
Temporarily hide the 'Install' section

### DIFF
--- a/src/docs/guide-fte.md
+++ b/src/docs/guide-fte.md
@@ -1,5 +1,5 @@
 # Getting Started
-
+<!-- 
 ## Install
 
 <tonic-tabs selected="tab-mac" id="get-started">
@@ -32,6 +32,7 @@
     iwr -useb https://sockets.sh/ps | iex
   </code>
 </tonic-tab-panel>
+-->
 
 ## Create Socket App
 This is similar to React's `Create React App`. The idea is that it provides a


### PR DESCRIPTION
When I look at the instructions it makes me think that first I need to run the curl+bash and __then__ use the create socket app.

I think that we should comment the Install section out to not make people deal with building from sources, installing xcode and all the dependancies when it's completely unnecessary.