### PR TITLE
remove node version required

### DIFF
--- a/src/docs/guide-fte.md
+++ b/src/docs/guide-fte.md
@@ -46,13 +46,11 @@ If you don't have npm installed but you want to use it, you can [download it her
 ### From Create Socket App
 
 Installing `Socket Runtime` from [Create Socket App](https://github.com/socketsupply/create-socket-app)
-will be instantly familiar to anyone who has used React's `Create React App`. To
-use Create Socket App you’ll need to have **Node 16.0.0** or later version installed
-on your computer.
+will be instantly familiar to anyone who has used React's `Create React App`. 
 
 The idea is to provide a few basic boilerplates and some strong opinions so
-you can get coding on a production-quality app as quickly as possible. Create an
-empty directory and try one of the following commands...
+you can get coding on a production-quality app as quickly as possible.
+Create an empty directory and try one of the following commands:
 
 <tonic-tabs selected="tab-csa-npx" id="get-csa">
   <tonic-tab id="tab-csa-npx" for="panel-csa-npx">npx</tonic-tab>


### PR DESCRIPTION
I removed the node version from the docs and from `create socket readme` as well, I think it's unnecessary since most users have `v18`, and also npm will print a warning if the Node version is outdated.